### PR TITLE
Auto-focus when creating a new cookie

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -412,6 +412,7 @@ function setEvents() {
 		$("#pasteCookie").slideUp('fast');
 		$("#newCookie").slideDown('fast');
 		$("#submitDiv").show();
+		$('#newCookie input.name').focus();
 		newCookie = true;
 		pasteCookie = false;
 	});


### PR DESCRIPTION
This change causes the name input element to be auto-focused when creating a new cookie. It allows for the user to enter cookie information more quickly, with the net result being an improvement to the overall user experience.
