### PR TITLE
Update to allow regex for name and value as well as domain

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -111,13 +111,15 @@ function _getMessage(string, args){
 
 function filterMatchesCookie(rule, name, domain, value){
 	var ruleDomainReg = new RegExp(rule.domain);
+	var ruleNameReg = new RegExp(rule.name);
+	var ruleValueReg = new RegExp(rule.value);
     if(rule.domain!=undefined && domain.match(ruleDomainReg) == null){
         return false
     }
-    if(rule.name!=undefined && name!=rule.name){
+    if(rule.name!=undefined && name.match(ruleNameReg) == null){
         return false
     }
-    if(rule.value!=undefined && value!=rule.value){
+    if(rule.value!=undefined && value.match(ruleValueReg) == null){
         return false
     }
     return true


### PR DESCRIPTION
Refs issue #83 

Added a regex match for name and value in the same coding style as domain in filterMatchesCookie.

This works for me at least with blocked cookies - can now block by name with regex - but I don't know if this is going to break other functionality - blocking is my main use of the addon.