### PR TITLE
Save Cookies on ctrl+return keystroke fixes fcapano/Edit-This-Cookie#132

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -538,7 +538,16 @@ function setEvents() {
 		$(this).css("margin-top", "-" + ( $(this).height()/2 ) + "px" );
 		$(this).css("margin-left", "-" + ( $(this).width()/2 ) + "px" );
 	});
-	
+
+	$('textarea.value, input.domain, input.path').keydown(function (event) {
+	if (event.ctrlKey && event.keyCode == 13) {
+		submit(currentTabID);
+		console.log('trigger save (submit)');
+		event.preventDefault();
+		event.stopPropagation();
+	}
+});
+
 	setCookieEvents();
 }
 


### PR DESCRIPTION
add event listener to value (textarea), domain and path field to
save all entries by hitting ctrl+return.

This keystroke allows to save changes faster.