### PR TITLE
change getHost to ignore port number

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -5,7 +5,7 @@ function escapeJQ(string){
     return escapeVar.text(string).html()
 }
 function getHost(url){
-    return(url.match(/:\/\/(.[^/]+)/)[1]).replace("www.","")
+    return(url.match(/:\/\/(.[^:/]+)/)[1]).replace("www.","")
 }
 function addBlockRule(rule){
     var dfilters=data.filters;


### PR DESCRIPTION
As per issue #100. People seem to keep the default host which includes the port number.