### PR TITLE
Associate labels with their inputs

### DIFF
--- a/options_pages/user_preferences.html
+++ b/options_pages/user_preferences.html
@@ -39,48 +39,48 @@
 			<hr>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="showAlerts"/>
-				<label class="formLabel" i18n="Show_Alerts"></label>
+				<label for="showAlerts" class="formLabel" i18n="Show_Alerts"></label>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="showCommandsLabels"/>
-				<label class="formLabel" i18n="ShowCommandsLabels"></label>
+				<label for="showCommandsLabels" class="formLabel" i18n="ShowCommandsLabels"></label>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="refreshAfterSubmit"/>
-				<label class="formLabel" i18n="reloadAfterChanges"></label>
+				<label for="refreshAfterSubmit" class="formLabel" i18n="reloadAfterChanges"></label>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="skipCacheRefresh"/>
-				<label id="skipCacheRefreshLabel" class="formLabel" i18n="skipCacheOnReload"></label>
+				<label for="skipCacheRefresh" id="skipCacheRefreshLabel" class="formLabel" i18n="skipCacheOnReload"></label>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="showChristmasIcon"/>
-				<label class="formLabel" i18n="Show_Christmas_Icon"></label>
+				<label for="showChristmasIcon" class="formLabel" i18n="Show_Christmas_Icon"></label>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="showContextMenu"/>
-				<label class="formLabel" i18n="Show_ContextMenu"></label>
+				<label for="showContextMenu" class="formLabel" i18n="Show_ContextMenu"></label>
 				<a id="showContextMenuHelper" class="helper" i18n_title="Show_ContextMenu_helper">?</a>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="showDevToolsPanel"/>
-				<label class="formLabel" i18n="Show_DevTools_Panel"></label>
+				<label for="showDevToolsPanel" class="formLabel" i18n="Show_DevTools_Panel"></label>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="showFlagAndDeleteAll"/>
-				<label class="formLabel" i18n="Show_Flag_And_Delete_All"></label>
+				<label for="showFlagAndDeleteAll" class="formLabel" i18n="Show_Flag_And_Delete_All"></label>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="showDomain"/>
-				<label class="formLabel" i18n="Show_Domain"></label>
+				<label for="showDomain" class="formLabel" i18n="Show_Domain"></label>
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="showDomainBeforeName"/>
-				<label class="formLabel" id="showDomainBeforeNameLabel" i18n="Show_Domain_Before_Name"></label>
+				<label for="showDomainBeforeName" class="formLabel" id="showDomainBeforeNameLabel" i18n="Show_Domain_Before_Name"></label>
 			</div>
 			<div class="formLine">
 				<span class="ui-icon ui-icon-minus"  width="30px" style="float:left; margin-right:11.5px; margin-top: 2px;"></span>
-				<label class="formLabel" i18n="Sort_Cookies"></label>
+				<label for="sortCookiesType" class="formLabel" i18n="Sort_Cookies"></label>
 				<select type="select" id="sortCookiesType">
 					<option value="domain_alpha" i18n="Sort_Cookies_Domain_Alpha"></option>
 					<option value="alpha" i18n="Sort_Cookies_Alpha"></option>
@@ -88,11 +88,11 @@
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="useMaxDate">
-				<label class="formLabel" i18n="Max_Date_Option"></label>
+				<label for="useMaxDate" class="formLabel" i18n="Max_Date_Option"></label>
 			</div>
 			<div class="formLine" id="maxDateContainer">
 				<span class="ui-icon ui-icon-minus"  width="30px" style="float:left; margin-right:11.5px; margin-top: 2px;"></span>
-				<label class="formLabel" i18n="Max_Date" id="maxDateLabel"></label>
+				<label for="maxDate" class="formLabel" i18n="Max_Date" id="maxDateLabel"></label>
 				<input type="text" class="checkbox" id="maxDate" value="1" size="5">
 				<div id="maxDateType">
 					<input type="radio" id="radioHour" 	name="radioMaxDate" value="3600"/>							<label for="radioHour" 	i18n="hour"></label>
@@ -108,13 +108,13 @@
 			</div>
 			<div class="formLine">
 				<input type="checkbox" class="checkbox" id="useCustomLocale">
-				<label class="formLabel" i18n="Use_Custom_Locale"></label>:
+				<label for="useCustomLocale" class="formLabel" i18n="Use_Custom_Locale"></label>:
 				<select type="select" class="" id="customLocale">
 				</select>
 			</div>
 			<div class="formLine">
 				<span class="ui-icon ui-icon-minus"></span>
-				<label class="formLabel" i18n="Copy_Cookies_Type"></label>
+				<label for="copyCookiesType" class="formLabel" i18n="Copy_Cookies_Type"></label>
 				<select type="select" id="copyCookiesType">
 					<option value="json">JSON</option>
 					<option value="netscape">Netscape HTTP Cookie File</option>


### PR DESCRIPTION
Having labels associated with their input elements is useful for accessibility, especially with check-boxes.