### PR TITLE
fix #167

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -21,7 +21,8 @@ function start() {
 	var arguments = getUrlVars();
 	if(arguments.url == undefined) {
 		chrome.tabs.query(
-			{active: true},
+			{active: true,
+			 lastFocusedWindow: true},
 			function(tabs) {
 				url = tabs[0].url;
 				currentTabID = tabs[0].id;


### PR DESCRIPTION
Fixes the issue where cookies were shown for the tab active in the first window opened rather then the currently focused window. 

@fcapano it would be greatly appreciated if you find the time to republish the extension on Chrome's store. 