### PR TITLE
Add support for Samesite flag

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -409,16 +409,16 @@
    "editThis_URL": {
       "message": "URL"
    },
-   "editThis_sameSite": {
-    "message": "Samesite Attribute"
+   "editThis_SameSite": {
+    "message": "SameSite"
    },
-   "editThis_sameSite_None": {
+   "editThis_SameSite_None": {
     "message": "No Restriction"
    },
-   "editThis_sameSite_Lax": {
+   "editThis_SameSite_Lax": {
     "message": "Lax"
    },
-   "editThis_sameSite_Strict": {
+   "editThis_SameSite_Strict": {
     "message": "Strict"
    }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -408,5 +408,17 @@
    },
    "editThis_URL": {
       "message": "URL"
+   },
+   "editThis_sameSite": {
+    "message": "Samesite Attribute"
+   },
+   "editThis_sameSite_None": {
+    "message": "No Restriction"
+   },
+   "editThis_sameSite_Lax": {
+    "message": "Lax"
+   },
+   "editThis_sameSite_Strict": {
+    "message": "Strict"
    }
 }

--- a/devtools/panel.html
+++ b/devtools/panel.html
@@ -38,6 +38,7 @@
 							<th class="minColumn">HostOnly</th>
 							<th class="minColumn">Secure</th>
 							<th class="minColumn">HttpOnly</th>
+							<th class="minColumn">SameSite</th>
 							<th class="hiddenColumn">StoreId</th>
 						</tr>
 					</thead>

--- a/devtools/panel.js
+++ b/devtools/panel.js
@@ -169,7 +169,7 @@ function updateCookie() {
 	var hostOnly 	= getValue(7, $cols);
 	var secure 		= getValue(8, $cols);
 	var httpOnly 	= getValue(9, $cols);
-	var sameSite  = getValue(10, $cols);
+	var sameSite	= getValue(10, $cols);
 	var origName 	= getValue(11, $cols);
 	var storeId 	= getValue(12, $cols);
 

--- a/devtools/panel.js
+++ b/devtools/panel.js
@@ -75,6 +75,13 @@ function createTable(message) {
 		$row.append($("<td/>").append($("<input/>").attr("type", "checkbox").addClass("hostOnlyCB").prop("checked", currentC.hostOnly)));
 		$row.append($("<td/>").append($("<input/>").attr("type", "checkbox").prop("checked", currentC.secure)));
 		$row.append($("<td/>").append($("<input/>").attr("type", "checkbox").prop("checked", currentC.httpOnly)));
+
+		var $options = $("<select/>").append("<option selected='selected' value='no_restriction'>None</option>'");
+		$options.append("<option value='lax'>Lax</option>'");
+		$options.append("<option value='strict'>Strict</option>'");
+		$options.val(currentC.sameSite);
+
+		$row.append($("<td/>").append($options));
 		$row.append($("<td/>").addClass("hiddenColumn").text(currentC.name));
 		$row.append($("<td/>").addClass("hiddenColumn").text(currentC.storeId));
 		$tableBody.append($row);
@@ -135,12 +142,18 @@ function updateCookie() {
 	var isCheckbox = function(element) {
 		return $("input", element).length;
 	};
+	var isSelect = function(element) {
+		return $("select", element).length;
+	}
 	var getValue = function(column, container) {
 		element = container[column];
 		if (isCheckbox(element)) {
 			return $(element).children(0).prop("checked");
 		} else if (isForm(element)) {
 			return $("textarea", element).first().val();
+		}
+		else if (isSelect(element)) {
+			return $("select",element).val();
 		} else {
 			return $(element).text();
 		}
@@ -156,9 +169,10 @@ function updateCookie() {
 	var hostOnly 	= getValue(7, $cols);
 	var secure 		= getValue(8, $cols);
 	var httpOnly 	= getValue(9, $cols);
-	var origName 	= getValue(10, $cols);
-	var storeId 	= getValue(11, $cols);
-	
+	var sameSite  = getValue(10, $cols);
+	var origName 	= getValue(11, $cols);
+	var storeId 	= getValue(12, $cols);
+
 	newCookie = {};
 	newCookie.url = tabURL;
 	newCookie.name = name.replace(";", "").replace(",", "");
@@ -175,6 +189,7 @@ function updateCookie() {
 	}
 	newCookie.secure = secure;
 	newCookie.httpOnly = httpOnly;
+	newCookie.sameSite = sameSite;
 	
 	backgroundPageConnection.postMessage({
 		action : "submitCookie",

--- a/devtools/panel.js
+++ b/devtools/panel.js
@@ -52,17 +52,17 @@ function createTable(message) {
 
 	for (var i = 0; i < cookieList.length; i++) {
 		currentC = cookieList[i];
-		
+
 		var domainDisabled = (currentC.hostOnly) ? "disabled" : "";
 		var expirationDisabled = (currentC.session) ? "disabled" : "";
-		
+
 		$row = $("<tr/>");
 		$row.append($("<td/>").addClass("hiddenColumn").text(i));
 		$row.append($("<td/>").addClass("editable").text(currentC.name));
 		$row.append($("<td/>").addClass("editable").text(currentC.value));
 		$row.append($("<td/>").addClass("editable domain " + domainDisabled).text(currentC.domain));
 		$row.append($("<td/>").addClass("editable").text(currentC.path));
-		
+
 		if(currentC.session) {
 			expDate = new Date();
 			expDate.setFullYear(expDate.getFullYear() + 1);
@@ -70,23 +70,25 @@ function createTable(message) {
 			expDate = new Date(currentC.expirationDate * 1000.0);
 		}
 		$row.append($("<td/>").addClass("editable expiration " + expirationDisabled).text(expDate));
-		
+
 		$row.append($("<td/>").append($("<input/>").attr("type", "checkbox").addClass("sessionCB").prop("checked", currentC.session)));
 		$row.append($("<td/>").append($("<input/>").attr("type", "checkbox").addClass("hostOnlyCB").prop("checked", currentC.hostOnly)));
 		$row.append($("<td/>").append($("<input/>").attr("type", "checkbox").prop("checked", currentC.secure)));
 		$row.append($("<td/>").append($("<input/>").attr("type", "checkbox").prop("checked", currentC.httpOnly)));
 
-		var $options = $("<select/>").append("<option selected='selected' value='no_restriction'>None</option>'");
-		$options.append("<option value='lax'>Lax</option>'");
-		$options.append("<option value='strict'>Strict</option>'");
-		$options.val(currentC.sameSite);
+		var $sameSite = $("<select/>");
+		$sameSite.append($("<option/>").attr("value", "no_restriction").attr("i18n", "SameSite_None"));
+		$sameSite.append($("<option/>").attr("value", "lax").attr("i18n", "SameSite_Lax"));
+		$sameSite.append($("<option/>").attr("value", "strict").attr("i18n", "SameSite_Strict"));
+		$sameSite.val(currentC.sameSite);
+		$row.append($("<td/>").append($sameSite));
 
-		$row.append($("<td/>").append($options));
 		$row.append($("<td/>").addClass("hiddenColumn").text(currentC.name));
 		$row.append($("<td/>").addClass("hiddenColumn").text(currentC.storeId));
 		$tableBody.append($row);
-		
 	}
+
+	localizePage();
 
 	setEvents();
 }
@@ -100,7 +102,7 @@ function setEvents() {
 		else
 			$domain.removeClass("disabled");
 	});
-	
+
 	$(".hostOnlyCB").click(function() {
 		var checked = $(this).prop("checked");
 		var $domain = $(".domain", $(this).parent().parent()).first();
@@ -109,11 +111,11 @@ function setEvents() {
 		else
 			$domain.removeClass("disabled");
 	});
-	
+
 	$(":checkbox").click(function() {
 		updateCookie.call($(this).parent().first());
 	});
-	
+
 	$("#cookieTable").tablesorter({
 		// sort on the first column and third column in ascending order
 		sortList : [[1, 0]],
@@ -153,7 +155,7 @@ function updateCookie() {
 			return $("textarea", element).first().val();
 		}
 		else if (isSelect(element)) {
-			return $("select",element).val();
+			return $("select", element).val();
 		} else {
 			return $(element).text();
 		}
@@ -190,7 +192,7 @@ function updateCookie() {
 	newCookie.secure = secure;
 	newCookie.httpOnly = httpOnly;
 	newCookie.sameSite = sameSite;
-	
+
 	backgroundPageConnection.postMessage({
 		action : "submitCookie",
 		cookie : newCookie,

--- a/js/popup.js
+++ b/js/popup.js
@@ -233,6 +233,8 @@ function createAccordionList(cks, callback, callbackArguments) {
 		$(".path",    cookie).val(currentC.path);
 		$(".storeId", cookie).val(currentC.storeId);
 
+		$(".sameSite",cookie).val(currentC.sameSite);
+
 		if(currentC.isProtected)
 			$(".unprotected", cookie).hide();
 		else
@@ -732,6 +734,7 @@ function formCookieData(form) {
 	var session    = $(".session",    form).prop("checked");
 	var storeId    = $(".storeId",    form).val();
 	var expiration = $(".expiration", form).val();
+	var sameSite   = $(".sameSite"  , form).val();
 
 	var newCookie = {};
 	newCookie.url = buildUrl(secure, domain, path);
@@ -763,6 +766,7 @@ function formCookieData(form) {
 	}
 	newCookie.secure = secure;
 	newCookie.httpOnly = httpOnly;
+	newCookie.sameSite = sameSite;
 
 	return newCookie;
 }

--- a/js/popup.js
+++ b/js/popup.js
@@ -232,7 +232,6 @@ function createAccordionList(cks, callback, callbackArguments) {
 		$(".domain",  cookie).val(currentC.domain);
 		$(".path",    cookie).val(currentC.path);
 		$(".storeId", cookie).val(currentC.storeId);
-
 		$(".sameSite",cookie).val(currentC.sameSite);
 
 		if(currentC.isProtected)

--- a/popup.html
+++ b/popup.html
@@ -165,6 +165,12 @@
 						<input class="storeId input" type="text" disabled="disabled"  style="display:none;">
 						<label class="formLabel" i18n="expiration"></label>
 						<input class="expiration input" type="text">
+						<label class="formLabel" i18n="sameSite"></label>
+						<select class="sameSite input" type="text">
+							<option selected="selected" i18n="sameSite_None" value="no_restriction"></option>
+							<option i18n="sameSite_Lax" value="lax"></option>
+							<option i18n="sameSite_Strict" value="strict"></option>
+						</select>
 				</div>
 				<div class="cookie-row" style="margin-top: 5px;">
 					<div>
@@ -210,6 +216,12 @@
 						<input class="path input" type="text">
 						<label class="formLabel" i18n="expiration"></label>
 						<input class="expiration input" type="text">
+						<label class="formLabel" i18n="sameSite"></label>
+						<select class="sameSite input" type="text">
+							<option selected="selected" i18n="sameSite_None" value="no_restriction"></option>
+							<option i18n="sameSite_Lax" value="lax"></option>
+							<option i18n="sameSite_Strict" value="strict"></option>
+						</select>
 					</div>
 					<div class="cookie-row" style="width: 97%;">
 						<div>

--- a/popup.html
+++ b/popup.html
@@ -165,11 +165,11 @@
 						<input class="storeId input" type="text" disabled="disabled"  style="display:none;">
 						<label class="formLabel" i18n="expiration"></label>
 						<input class="expiration input" type="text">
-						<label class="formLabel" i18n="sameSite"></label>
+						<label class="formLabel" i18n="SameSite"></label>
 						<select class="sameSite input" type="text">
-							<option selected="selected" i18n="sameSite_None" value="no_restriction"></option>
-							<option i18n="sameSite_Lax" value="lax"></option>
-							<option i18n="sameSite_Strict" value="strict"></option>
+							<option i18n="SameSite_None" value="no_restriction"></option>
+							<option i18n="SameSite_Lax" value="lax"></option>
+							<option i18n="SameSite_Strict" value="strict"></option>
 						</select>
 				</div>
 				<div class="cookie-row" style="margin-top: 5px;">


### PR DESCRIPTION
Implements changes requested in #202.

I've tested both DevTools and the Panel, and both seem to work fine for creating new cookies and viewing existing ones, GitHub was the only site I could find that actually uses cookies with the Samesite flag though.

Initially, I was going to add this as another checkbox, but Samesite can have 3 values so that wouldn't work so I decided to go with a drop-down/select.

I've added localisation to `en` but I left the others for someone else to decide, the DevTools area doesn't use localisation as the existing work didn't seem to, I also chose to use "None" instead of "No Restriction" there which isn't exactly correct but wastes less space.

P.S I'm still pretty new to contributing to projects so apologies if I've missed anything/not followed conventions exactly.