### PR TITLE
Force popup repaint on start

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -15,6 +15,16 @@ $.fx.speeds._default = 200;
 jQuery(document).ready(function(){
 	++data.nPopupClicked;
 	start();
+
+	/**
+	 * Force Repaint
+	 * Temporary workaround for Chromium #428044 bug
+	 * https://bugs.chromium.org/p/chromium/issues/detail?id=428044#c35
+	 */
+	let body = $('body').css('display', 'none');
+	setTimeout(() => {
+		body.css('display', '');
+	}, 100);
 });
 
 function start() {


### PR DESCRIPTION
Forces the pop to repaint the layout after 100ms. A temporary fix https://github.com/fcapano/Edit-This-Cookie/issues/203. One small negative side-effects is a quick flicker in the beginning.