### PR TITLE
Build cookie url with the same protocol as the search url

### DIFF
--- a/js/cookie_helpers.js
+++ b/js/cookie_helpers.js
@@ -1,13 +1,18 @@
-function buildUrl(secure, domain, path){
-	if(domain.substr(0, 1) === '.')
+function buildUrl(domain, path, searchUrl){
+    // Keep same protocol as searchUrl
+    // This fixes a bug when we want to unset 'secure' property in an https domain
+    var secure = searchUrl.indexOf("https://") === 0;
+
+    if(domain.substr(0, 1) === '.')
 		domain = domain.substring(1);
+
 	return "http" + ((secure) ? "s" : "") + "://" + domain + path;
 }
 
-function deleteAll(cookieList) {
+function deleteAll(cookieList, searchUrl) {
     for(var i=0; i<cookieList.length; i++) {
         var curr = cookieList[i];
-        var url = buildUrl(curr.secure, curr.domain, curr.path);
+        var url = buildUrl(curr.domain, curr.path, searchUrl);
         deleteCookie(url, curr.name, curr.storeId);
     }
 }

--- a/js/popup.js
+++ b/js/popup.js
@@ -359,7 +359,7 @@ function setEvents() {
 			if(!filterMatchesCookie(newRule,currentCookie.name,currentCookie.domain,currentCookie.value))
 				continue;
 
-			var tmpUrl = buildUrl(currentCookie.secure, currentCookie.domain, currentCookie.path);
+			var tmpUrl = buildUrl(currentCookie.domain, currentCookie.path, url);
 			deleteCookie(tmpUrl, currentCookie.name, currentCookie.storeId);
 		}
 		data.nCookiesFlagged += cookieList.length;
@@ -375,7 +375,7 @@ function setEvents() {
 
 		var okFunction = function() {
 			nCookiesDeletedThisTime = cookieList.length;
-			deleteAll(cookieList);
+			deleteAll(cookieList, url);
 			data.nCookiesDeleted += nCookiesDeletedThisTime;
 			doSearch();
 		}
@@ -401,7 +401,7 @@ function setEvents() {
 					newRule.domain = currentCookie.domain;
 					newRule.name = currentCookie.name;
 					addBlockRule(newRule);
-					var tmpUrl = buildUrl(currentCookie.secure, currentCookie.domain, currentCookie.path);
+					var tmpUrl = buildUrl(currentCookie.domain, currentCookie.path, url);
 					deleteCookie(tmpUrl, currentCookie.name, currentCookie.storeId);
 				}
 				data.nCookiesFlagged += nCookiesFlaggedThisTime;
@@ -521,7 +521,7 @@ function setCookieEvents() {
 		var secure	= $(".secure", cookie).prop("checked");
 		var storeId = $(".storeId", cookie).val();
 		var okFunction = function() {
-			var tmpUrl = buildUrl(secure, domain, path);
+			var tmpUrl = buildUrl(domain, path, url);
 			deleteCookie(tmpUrl, name, storeId, function(success) {
 				if(success === true) {
 					var head = cookie.prev('h3');
@@ -746,7 +746,7 @@ function formCookieData(form) {
 	var sameSite   = $(".sameSite"  , form).val();
 
 	var newCookie = {};
-	newCookie.url = buildUrl(secure, domain, path);
+	newCookie.url = buildUrl(domain, path, url);
 	newCookie.name = name.replace(";", "").replace(",", "");
 	value = value.replace(";", "");
 	newCookie.value = value;


### PR DESCRIPTION
## Issue
Since the support of url search, it was not possible anymore to uncheck `secure` property on an https domain.
When calling `chrome.cookies.set`, an error was logged and the cookie was not updated. So `secure` is still checked

See video for url `https://github.com/fcapano/Edit-This-Cookie`
![edit-this-cookie-secure-before](https://user-images.githubusercontent.com/1867939/39642644-5fb962be-4fa0-11e8-990e-348461e0e395.gif)


## Solution
`buildUrl` now defines the protocol based on url in search bar.

See video:
![edit-this-cookie-secure-after](https://user-images.githubusercontent.com/1867939/39642653-65d9dbba-4fa0-11e8-8650-1ae9c0455b15.gif)

