### PR TITLE
Optional desktop notifications

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -419,5 +419,8 @@
     },
     "editThis_SameSite_Strict": {
         "message": "Strict"
+    },
+    "editThis_ShowUpdateNotifications": {
+        "message": "Show Desktop Notifications When EditThisCookie Updates"
     }
 }

--- a/js/background.js
+++ b/js/background.js
@@ -19,7 +19,7 @@ var oldVersion = data.lastVersionRun;
 
 data.lastVersionRun = currentVersion;
 
-if (oldVersion !== currentVersion) {
+if (preferences.showUpdateNotifications && oldVersion !== currentVersion) {
     if (oldVersion === undefined) { //Is firstrun
         chrome.tabs.create({ url: 'http://www.editthiscookie.com/start/' });
     } else {

--- a/js/data.js
+++ b/js/data.js
@@ -52,7 +52,10 @@ var preferences_template = {
     },
     "showLabelChooserBanner": {
         "default_value": false
-    }
+	},
+	"showUpdateNotifications":{
+		"default_value": true
+	}
 };
 
 var data_template = {


### PR DESCRIPTION
I feel annoyed and sad when I see an extension that makes unhidable desktop notifications, because I want the open source community to trust that others will donate to them in good faith, and not force them to see advertisements as punishment for using open source software that you don't have to pay to host.

I like editthiscookie, but this annoyance is enough to make me want to go through the trouble of opening this PR.