### PR TITLE
Fix: Skip the www removal when the host does not start with www

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -14,7 +14,7 @@ Array.prototype.toTop = function (a) {
 };
 
 function getHost(url) {
-    return (url.match(/:\/\/(.[^:/]+)/)[1]).replace("www.", "")
+    return (url.match(/:\/\/(.[^:/]+)/)[1]).replace(/^www\./, "")
 }
 
 function addBlockRule(rule) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSn5dhR3eTtYJoXe4DW2j9oFWIg71/f21Z3b6tzFva3M9xo07+xUWo9qLmyWkMeisCMhT7VNsuRbP4kIWjWFcFCi/FgtYCWwCV29CVDvj5Xv+Jzrp8znbCICaczf4ZNqCDdk3WrvSBqp1WqRqJ5q8Y7A0aoFRvMoIxqn1/u11rrwIDAQAB",
     "name": "EditThisCookie",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "__MSG_editThis_description__",
     "icons": {
         "16": "img/icon_16x16.png",


### PR DESCRIPTION
By default the creation of the cookie is set with the domain name returned by the getHost function.

This function strip the `www.` of the domain name, in some cases it does not make sense to remove it.

I propose to change the `replace` first parameter from a `substr` to a `regexp` pattern
such as to replace the `www.` only if it's placed at the beginning of the hotsname.

Ex:
https://www.github.com/ → github.com
https://test.env.www.github.com/ → test.env.www.github.com