### PR TITLE
Make links https

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,5 +1,5 @@
 EditThisCookie is a Chrome extension made by Francesco Capano
-http://editthiscookie.com/
+https://editthiscookie.com/
 
 
 This file is part of "EditThisCookie".

--- a/js/background.js
+++ b/js/background.js
@@ -21,11 +21,11 @@ data.lastVersionRun = currentVersion;
 
 if (oldVersion !== currentVersion) {
     if (oldVersion === undefined) { //Is firstrun
-        chrome.tabs.create({ url: 'http://www.editthiscookie.com/start/' });
+        chrome.tabs.create({ url: 'https://www.editthiscookie.com/start/' });
     } else {
         chrome.notifications.onClicked.addListener(function (notificationId) {
             chrome.tabs.create({
-                url: 'http://www.editthiscookie.com/changelog/'
+                url: 'https://www.editthiscookie.com/changelog/'
             });
             chrome.notifications.clear(notificationId, function (wasCleared) { });
         });

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
         "128": "img/icon_128x128.png"
     },
     "default_locale": "en",
-    "homepage_url": "http://www.editthiscookie.com/",
+    "homepage_url": "https://www.editthiscookie.com/",
     "browser_action": {
         "default_icon": {
             "19": "img/icon_19x19.png",

--- a/options_pages/options_page_chooser.js
+++ b/options_pages/options_page_chooser.js
@@ -10,10 +10,10 @@ function setPageCooserEvents() {
             return;
         var id = $(this).attr("id");
         if (id == "getting_started") {
-            openExtPage("http://www.editthiscookie.com/start/");
+            openExtPage("https://www.editthiscookie.com/start/");
             return;
         } else if (id == "help") {
-            openExtPage("http://www.editthiscookie.com/faq/");
+            openExtPage("https://www.editthiscookie.com/faq/");
             return;
         }
         ls.set("option_panel", panel);

--- a/popup.html
+++ b/popup.html
@@ -270,7 +270,7 @@
 
         <div id="submitDiv">
             <i id="submitButton" class="fa fa-check" i18n_title="Alert_submitAll"></i>
-            <a id="helpButton" i18n="help" href="http://www.editthiscookie.com/start/" target="_blank">
+            <a id="helpButton" i18n="help" href="https://www.editthiscookie.com/start/" target="_blank">
             </a>
         </div>
     </div>


### PR DESCRIPTION
Making the links secure for obvious reasons, but the impetus was some issue with redirects on the non-https version of the site.

Examples:

```
http://editthiscookie.com/start redirects to https://www.editthiscookie.comstart/
```

```
http://www.editthiscookie.com/faq/ redirects to https://www.editthiscookie.comfaq/
```