### PR TITLE
chore: update and support for chrome manifest version 3

### DIFF
--- a/js/options_main_page.js
+++ b/js/options_main_page.js
@@ -1,15 +1,38 @@
-var panel = JSON.parse(localStorage.getItem("option_panel"));
-var arguments = getUrlVars();
-var element;
-
-if (panel === "null" || panel === null || panel === undefined) {
-    element = "support";
-} else {
-    element = panel;
+// Function to get URL variables
+function getUrlVars() {
+    var vars = {};
+    window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
+        vars[key] = value;
+    });
+    return vars;
 }
 
-if (arguments.page !== undefined) {
-    element = arguments.page;
+// Function to redirect based on the panel state
+function redirectBasedOnPanel(panel) {
+    var arguments = getUrlVars();
+    var element;
+
+    if (panel === "null" || panel === null || panel === undefined) {
+        element = "support";
+    } else {
+        element = panel;
+    }
+
+    if (arguments.page !== undefined) {
+        element = arguments.page;
+    }
+
+    location.href = "/options_pages/" + element + ".html";
 }
 
-location.href = "/options_pages/" + element + ".html";
+// Get the 'option_panel' value from chrome.storage
+chrome.storage.local.get("option_panel", function(result) {
+    if (chrome.runtime.lastError) {
+        console.error("Error getting option_panel: ", chrome.runtime.lastError);
+        // In case of error, default to 'support'
+        redirectBasedOnPanel("support");
+    } else {
+        // Call the redirect function with the retrieved panel value
+        redirectBasedOnPanel(result.option_panel);
+    }
+});

--- a/js/popup.js
+++ b/js/popup.js
@@ -217,14 +217,16 @@ function createAccordionList(cks, callback, callbackArguments) {
     let createAccordionCallback = callback;
     let createAccordionCallbackArguments = callbackArguments;
 
-    try {
-        $("#cookiesList").accordion("destroy");
-    } catch (e) {
-        console.warn(e.message)
+    // Check if the accordion is initialized before attempting to destroy it
+    if ($("#cookiesList").hasClass("ui-accordion")) {
+        try {
+            $("#cookiesList").accordion("destroy");
+        } catch (e) {
+            console.warn(e.message);
+        }
     }
 
-    if (cks === null)
-        cks = cookieList;
+    if (cks === null) cks = cookieList;
     for (var i = 0; i < cks.length; i++) {
         currentC = cks[i];
 
@@ -304,6 +306,7 @@ function createAccordionList(cks, callback, callbackArguments) {
         }
     });
 }
+
 
 function importCookies() {
     var nCookiesImportedThisTime = 0;

--- a/js/utils.js
+++ b/js/utils.js
@@ -137,23 +137,24 @@ function showPopup(info, tab) {
     var tabID = encodeURI(tab.id);
     var tabIncognito = encodeURI(tab.incognito);
 
-    var urlToOpen = chrome.extension.getURL("popup.html") + "?url=" + tabUrl + "&id=" + tabID + "&incognito=" + tabIncognito;
+    var urlToOpen = chrome.runtime.getURL("popup.html") + "?url=" + tabUrl + "&id=" + tabID + "&incognito=" + tabIncognito;
 
     chrome.tabs.query({ 'windowId': chrome.windows.WINDOW_ID_CURRENT }, function (tabList) {
         for (var x = 0; x < tabList.length; x++) {
             var cTab = tabList[x];
             if (cTab.url.indexOf(urlToOpen) === 0) {
                 chrome.tabs.update(cTab.id, {
-                    'selected': true
+                    'active': true // Updated from 'selected' to 'active'
                 });
-                return
+                return;
             }
         }
         chrome.tabs.create({
             'url': urlToOpen
-        })
-    })
+        });
+    });
 }
+
 
 function copyToClipboard(text) {
     if (text === undefined)

--- a/lib/custom_i18n.js
+++ b/lib/custom_i18n.js
@@ -1,6 +1,10 @@
 //TAKEN FROM:
 //https://adblockforchrome.googlecode.com/svn/trunk/port.js
 
+// Updated August 2024 to support Chrome manifest v3. Replaced chrome.extension.getURL
+// with chrome.runtime.getURL.
+// - cldevdad
+
 // Chrome to Safari port
 // Author: Michael Gundlach (gundlach@gmail.com)
 // License: GPLv3 as part of adblockforchrome.googlecode.com
@@ -9,8 +13,8 @@
 chrome.i18n = chrome.i18n || {};
 chrome.i18n = (function() {
 
-  //Supported locales as in:
-  //https://developers.google.com/chrome/web-store/docs/i18n?hl=it#localeTable
+  // Supported locales as in:
+  // https://developers.google.com/chrome/web-store/docs/i18n?hl=it#localeTable
   var supportedLocales = 
 	[{"code":"ar", "name":"Arabic"},
 	{"code":"bg", "name":"Bulgarian"},
@@ -58,7 +62,7 @@ chrome.i18n = (function() {
 	
   function syncFetch(file, fn) {
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", chrome.extension.getURL(file), false);
+    xhr.open("GET", chrome.runtime.getURL(file), false);
     xhr.onreadystatechange = function() {
       if(this.readyState == 4 && this.responseText != "") {
         fn(this.responseText);
@@ -189,7 +193,7 @@ chrome.i18n = (function() {
       return "";
     },
     
-    //Returns the list of locales that are actually present in the locale directory
+    // Returns the list of locales that are actually present in the locale directory
     getExistingLocales: function (){
      var existingLocales = [];
   	 for (var i = 0; i < supportedLocales.length; i++) {
@@ -197,7 +201,7 @@ chrome.i18n = (function() {
         var file = "_locales/" + locale + "/messages.json";
 
         var xhr = new XMLHttpRequest();
-		xhr.open("GET", chrome.extension.getURL(file), false);
+		xhr.open("GET", chrome.runtime.getURL(file), false);
 		xhr.onreadystatechange = function() {
 		};
 		try {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSn5dhR3eTtYJoXe4DW2j9oFWIg71/f21Z3b6tzFva3M9xo07+xUWo9qLmyWkMeisCMhT7VNsuRbP4kIWjWFcFCi/FgtYCWwCV29CVDvj5Xv+Jzrp8znbCICaczf4ZNqCDdk3WrvSBqp1WqRqJ5q8Y7A0aoFRvMoIxqn1/u11rrwIDAQAB",
   "name": "EditThisCookie",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "__MSG_editThis_description__",
   "icons": {
     "16": "img/icon_16x16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,49 +1,41 @@
 {
-    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSn5dhR3eTtYJoXe4DW2j9oFWIg71/f21Z3b6tzFva3M9xo07+xUWo9qLmyWkMeisCMhT7VNsuRbP4kIWjWFcFCi/FgtYCWwCV29CVDvj5Xv+Jzrp8znbCICaczf4ZNqCDdk3WrvSBqp1WqRqJ5q8Y7A0aoFRvMoIxqn1/u11rrwIDAQAB",
-    "name": "EditThisCookie",
-    "version": "1.5.0",
-    "description": "__MSG_editThis_description__",
-    "icons": {
-        "16": "img/icon_16x16.png",
-        "48": "img/icon_48x48.png",
-        "128": "img/icon_128x128.png"
+  "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSn5dhR3eTtYJoXe4DW2j9oFWIg71/f21Z3b6tzFva3M9xo07+xUWo9qLmyWkMeisCMhT7VNsuRbP4kIWjWFcFCi/FgtYCWwCV29CVDvj5Xv+Jzrp8znbCICaczf4ZNqCDdk3WrvSBqp1WqRqJ5q8Y7A0aoFRvMoIxqn1/u11rrwIDAQAB",
+  "name": "EditThisCookie",
+  "version": "1.5.0",
+  "description": "__MSG_editThis_description__",
+  "icons": {
+    "16": "img/icon_16x16.png",
+    "48": "img/icon_48x48.png",
+    "128": "img/icon_128x128.png"
+  },
+  "default_locale": "en",
+  "homepage_url": "http://www.editthiscookie.com/",
+  "action": {
+    "default_icon": {
+      "19": "img/icon_19x19.png",
+      "38": "img/icon_38x38.png"
     },
-    "default_locale": "en",
-    "homepage_url": "http://www.editthiscookie.com/",
-    "browser_action": {
-        "default_icon": {
-            "19": "img/icon_19x19.png",
-            "38": "img/icon_38x38.png"
-        },
-        "default_title": "EditThisCookie",
-        "default_popup": "popup.html"
-    },
-    "devtools_page": "/devtools/devtools-page.html",
-    "background": {
-        "scripts": [
-            "/lib/jquery-3.3.1.min.js",
-            "/lib/object-watch.js",
-            "/js/cookie_helpers.js",
-            "/js/utils.js",
-            "/js/data.js",
-            "/js/background.js",
-            "/devtools/background-devtools.js",
-            "/js/ga.js"
-        ]
-    },
-    "options_page": "options_main_page.html",
-    "permissions": [
-        "tabs",
-        "\u003Call_urls\u003E",
-        "cookies",
-        "contextMenus",
-        "unlimitedStorage",
-        "notifications",
-        "storage",
-        "clipboardWrite"
-    ],
-    "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
-    "minimum_chrome_version": "41",
-    "manifest_version": 2,
-    "update_url": "http://clients2.google.com/service/update2/crx"
+    "default_title": "EditThisCookie",
+    "default_popup": "popup.html"
+  },
+  "devtools_page": "/devtools/devtools-page.html",
+  "background": {
+    "service_worker": "js/background.js"
+  },
+  "options_page": "options_main_page.html",
+  "permissions": [
+    "tabs",
+    "cookies",
+    "contextMenus",
+    "storage",
+    "notifications",
+    "clipboardWrite"
+  ],
+  "host_permissions": ["<all_urls>"],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src https://ssl.google-analytics.com"
+  },
+  "minimum_chrome_version": "88",
+  "manifest_version": 3,
+  "update_url": "http://clients2.google.com/service/update2/crx"
 }

--- a/options_pages/options_page_chooser.js
+++ b/options_pages/options_page_chooser.js
@@ -1,26 +1,39 @@
 jQuery(document).ready(function () {
-    setPageCooserEvents();
+    setPageChooserEvents();
 });
 
-//Set Events
-function setPageCooserEvents() {
+// Set Events
+function setPageChooserEvents() {
     $(".chooser").click(function () {
         var panel = $(this).attr("id");
+
         if ($(this).hasClass("selected"))
             return;
+
         var id = $(this).attr("id");
-        if (id == "getting_started") {
+
+        // Handle external page redirections
+        if (id === "getting_started") {
             openExtPage("http://www.editthiscookie.com/start/");
             return;
-        } else if (id == "help") {
+        } else if (id === "help") {
             openExtPage("http://www.editthiscookie.com/faq/");
             return;
         }
-        ls.set("option_panel", panel);
-        location.href = "/options_pages/" + id + ".html";
+
+        // Save the selected panel to chrome.storage
+        chrome.storage.local.set({ option_panel: panel }, function () {
+            if (chrome.runtime.lastError) {
+                console.error("Error setting option_panel: ", chrome.runtime.lastError);
+            } else {
+                // Redirect to the appropriate options page
+                location.href = "/options_pages/" + id + ".html";
+            }
+        });
     });
 }
 
+// Open an external page in a new tab
 function openExtPage(url) {
     chrome.tabs.getCurrent(function (tab) {
         chrome.tabs.create({
@@ -29,5 +42,5 @@ function openExtPage(url) {
             active: true,
             openerTabId: tab.id
         });
-    })
+    });
 }

--- a/options_pages/user_preferences.js
+++ b/options_pages/user_preferences.js
@@ -1,3 +1,5 @@
+importScripts('utils.js');
+
 $(document).ready(function () {
     $("input:checkbox, input:text, select").uniform();
     setOptions();


### PR DESCRIPTION
Updates the extension to Chrome  Manifest Version 3. It includes changes to the manifest.json to use a service worker for background tasks instead of background scripts, and it has been refactored to replace deprecated APIs.